### PR TITLE
fix: Quickly change the API url to prod

### DIFF
--- a/frontend/src/api/frontmatter.ts
+++ b/frontend/src/api/frontmatter.ts
@@ -5,7 +5,7 @@ class Request {
 
   public static async Post(path: string, data?: object): Promise<any> {
     try {
-      let result = await fetch("https://localhost:8080/" + path, {
+      let result = await fetch("https://api.theschedule.de/" + path, {
         method: "POST",
         headers: {
           "Content-Type": "application/json"
@@ -28,7 +28,7 @@ class Request {
   }
   public static async Get(path: string, headers?: HeadersInit): Promise<any> {
     try {
-      let result = await fetch("https://127.0.0.1:8080/" + path, {
+      let result = await fetch("https://api.theschedule.de/" + path, {
         headers,
         method: "GET",
         credentials: "include"

--- a/frontend/src/api/theBackend.ts
+++ b/frontend/src/api/theBackend.ts
@@ -6,7 +6,7 @@ class Request {
 
   public static async Post<T>(path: string, data?: object): Promise<T> {
     try {
-      let result = await fetch("https://localhost:8080/" + path, {
+      let result = await fetch("https://api.theschedule.de" + path, {
         method: "POST",
         headers: {
           "Content-Type": "application/json"
@@ -29,7 +29,7 @@ class Request {
   }
   public static async Get<T>(path: string, headers?: HeadersInit): Promise<T> {
     try {
-      let result = await fetch("https://localhost:8080/" + path, {
+      let result = await fetch("https://api.theschedule.de" + path, {
         headers,
         method: "GET",
         credentials: "include"


### PR DESCRIPTION
Real implementation depends on #58 , so this will work for now